### PR TITLE
Feature configurable classpath

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Suggests:
     testthat (>= 3.0.0)
 Type: Package
 Title: Loader of the NetCDF Java Library in R
-Version: 1.2.1-devel
+Version: 1.2.1
 Date: 2025-08-12
 Authors@R: as.person(c(
     "Santander Meteorology Group <http://meteo.unican.es> [cph]",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,7 @@ Suggests:
     testthat (>= 3.0.0)
 Type: Package
 Title: Loader of the NetCDF Java Library in R
-Version: 1.2.1
+Version: 1.2.1.9001
 Date: 2025-08-12
 Authors@R: as.person(c(
     "Santander Meteorology Group <http://meteo.unican.es> [cph]",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,8 +13,8 @@ Authors@R: as.person(c(
     "Joaquin Bedia <bediaj@unican.es> [aut, cre]",
     "Antonio S. Cofino <antonio.cofino@unican.es> [aut]",
     "Max Tuni <max@predictia.es> [ctb]",
-    "Manuel Vega <manuel.vega@unican.es> [ctb]"
-    "Maria Isabel de la Osa <mor427@alumnos.unican.es> [aut]",
+    "Manuel Vega <manuel.vega@unican.es> [ctb]",
+    "Maria Isabel de la Osa <mor427@alumnos.unican.es> [aut]"
     ))
 Maintainer: Joaquin Bedia <bediaj@unican.es>
 BugReports: https://github.com/SantanderMetGroup/loadeR.java/issues

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -20,7 +20,19 @@
         # Use ClassLoader to access MANIFEST.MF
         manifest_info <- tryCatch({
             # Load NetcdfFile class loader
-            netcdf_class <- rJava::.jfindClass("ucar/nc2/NetcdfFile")
+            netcdf_class <- tryCatch(rJava::.jfindClass("ucar/nc2/NetcdfFile"), error = function(e) NULL)
+
+            if (is.null(netcdf_class)) {
+                stop(
+                    paste(
+                        "NetCDF Java Classes not found. Set the classpath before loading the package:",
+                        'options(loadeR.java_classpath = "/opt/netcdf-java/netcdfAll-5.9.0.jar")',
+                        "library(loadeR.java)",
+                        sep = "\n"
+                    )
+                )
+            }
+            
             class_loader <- rJava::.jcall(netcdf_class, "Ljava/lang/ClassLoader;", "getClassLoader")
             manifest_url <- rJava::.jcall(class_loader, "Ljava/net/URL;", "getResource", "META-INF/MANIFEST.MF")
 
@@ -61,7 +73,12 @@
             ))
         } else {
             packageStartupMessage(
-                "You can manually set the NetCDF Java Library version using an R option before loading the package"
+                paste(
+                    "You can manually set the NetCDF Java Library version before loading the package:",
+                    'options(loadeR.java_forced_version = "X.Y.Z")',
+                    "library(loadeR.java)",
+                    sep = "\n"
+                )
             )
         }
         

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -15,8 +15,8 @@
         packageStartupMessage(sprintf("The maximum JVM heap space available is: %.2f GB", max_mem_gb))
         
         # Get forced netcdf version
-        forced <- getOption("loadeR.java.forced_version", "")
-
+        forced <- getOption("loadeR.java_forced_version", "")
+    
         # Use ClassLoader to access MANIFEST.MF
         manifest_info <- tryCatch({
             # Load NetcdfFile class loader
@@ -24,19 +24,7 @@
             class_loader <- rJava::.jcall(netcdf_class, "Ljava/lang/ClassLoader;", "getClassLoader")
             manifest_url <- rJava::.jcall(class_loader, "Ljava/net/URL;", "getResource", "META-INF/MANIFEST.MF")
 
-            if (rJava::is.jnull(manifest_url)) {
-                if (nzchar(forced)) {
-                    packageStartupMessage(sprintf(
-                        "NetCDF Java Library Forced Version: %s",
-                        forced
-                    ))
-                } else {
-                    packageStartupMessage(
-                        "NetCDF Java Library version could not be detected. You can set it manually via R option before loading the package"
-                    )
-                }
-                stop("MANIFEST.MF not found via NetcdfFile class loader")
-            }
+            if (rJava::is.jnull(manifest_url)) stop("MANIFEST.MF not found via NetcdfFile class loader")
 
             input_stream <- rJava::.jcall(manifest_url, "Ljava/io/InputStream;", "openStream")
             manifest <- rJava::.jnew("java/util/jar/Manifest", input_stream)
@@ -51,7 +39,7 @@
             names(extracted_fields) <- fields
 
             # Save netcdf version 
-            options(loadeR.java.detected_version = extracted_fields[["Implementation-Version"]])
+            options(loadeR.java_detected_version = extracted_fields[["Implementation-Version"]])
             extracted_fields
         }, error = function(e) {
             packageStartupMessage(e$message)
@@ -65,9 +53,21 @@
                 manifest_info[["Built-On"]]
             ))
         }
+
+        if (nzchar(forced)) {
+            warning(sprintf(
+                "NetCDF Java Library Forced Version: %s",
+                forced
+            ))
+        } else {
+            packageStartupMessage(
+                "You can manually set the NetCDF Java Library version using an R option before loading the package"
+            )
+        }
+        
         # Show the source of the netCDF-Java classpath used
-        cp_entries <- getOption("loadeR.netcdf_java_classpath_entries")
-        cp_msg <- getOption("loadeR.netcdf_java_classpath_msg")
+        cp_entries <- getOption("loadeR.java_classpath_entries")
+        cp_msg <- getOption("loadeR.java_classpath_msg")
         if (!is.null(cp_entries) && !is.null(cp_msg)) {
             packageStartupMessage(sprintf("netCDF-Java CLASSPATH from %s: %s", cp_msg,  paste(cp_entries, collapse = .Platform$path.sep)))
         } 

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -13,6 +13,9 @@
         max_mem_bytes <- rJava::.jcall(runtime, "J", "maxMemory")
         max_mem_gb <- round(max_mem_bytes / (1024^3), 2)
         packageStartupMessage(sprintf("The maximum JVM heap space available is: %.2f GB", max_mem_gb))
+        
+        # Get forced netcdf version
+        forced <- getOption("loadeR.java.forced_version", "")
 
         # Use ClassLoader to access MANIFEST.MF
         manifest_info <- tryCatch({
@@ -21,7 +24,19 @@
             class_loader <- rJava::.jcall(netcdf_class, "Ljava/lang/ClassLoader;", "getClassLoader")
             manifest_url <- rJava::.jcall(class_loader, "Ljava/net/URL;", "getResource", "META-INF/MANIFEST.MF")
 
-            if (rJava::is.jnull(manifest_url)) stop("MANIFEST.MF not found via NetcdfFile class loader")
+            if (rJava::is.jnull(manifest_url)) {
+                if (nzchar(forced)) {
+                    packageStartupMessage(sprintf(
+                        "NetCDF Java Library Forced Version: %s",
+                        forced
+                    ))
+                } else {
+                    packageStartupMessage(
+                        "NetCDF Java Library version could not be detected. You can set it manually via R option before loading the package"
+                    )
+                }
+                stop("MANIFEST.MF not found via NetcdfFile class loader")
+            }
 
             input_stream <- rJava::.jcall(manifest_url, "Ljava/io/InputStream;", "openStream")
             manifest <- rJava::.jnew("java/util/jar/Manifest", input_stream)
@@ -35,11 +50,11 @@
             })
             names(extracted_fields) <- fields
 
-            # Save extracted fields in package options
-            options(loadeR.java.manifest = extracted_fields)
+            # Save netcdf version 
+            options(loadeR.java.detected_version = extracted_fields[["Implementation-Version"]])
             extracted_fields
         }, error = function(e) {
-            packageStartupMessage("Could not read MANIFEST.MF via class loader:", e$message)
+            packageStartupMessage(e$message)
             NULL
         })
 
@@ -50,14 +65,12 @@
                 manifest_info[["Built-On"]]
             ))
         }
-
-    }
-
-    # Show the source of the netCDF-Java classpath used
-    cp_source <- getOption("loadeR.netcdf_java_classpath_source")
-    cp_msg <- getOption("loadeR.netcdf_java_classpath_msg")
-    if (!is.null(cp_source) && !is.null(cp_msg)) {
-        packageStartupMessage(sprintf("netCDF-Java CLASSPATH from %s: %s", cp_msg, cp_source))
+        # Show the source of the netCDF-Java classpath used
+        cp_entries <- getOption("loadeR.netcdf_java_classpath_entries")
+        cp_msg <- getOption("loadeR.netcdf_java_classpath_msg")
+        if (!is.null(cp_entries) && !is.null(cp_msg)) {
+            packageStartupMessage(sprintf("netCDF-Java CLASSPATH from %s: %s", cp_msg,  paste(cp_entries, collapse = .Platform$path.sep)))
+        } 
     }
     
     J("java.util.logging.Logger")$getLogger("")$setLevel(J("java.util.logging.Level")$SEVERE)

--- a/R/onAttach.R
+++ b/R/onAttach.R
@@ -52,6 +52,14 @@
         }
 
     }
+
+    # Show the source of the netCDF-Java classpath used
+    cp_source <- getOption("loadeR.netcdf_java_classpath_source")
+    cp_msg <- getOption("loadeR.netcdf_java_classpath_msg")
+    if (!is.null(cp_source) && !is.null(cp_msg)) {
+        packageStartupMessage(sprintf("netCDF-Java CLASSPATH from %s: %s", cp_msg, cp_source))
+    }
+    
     J("java.util.logging.Logger")$getLogger("")$setLevel(J("java.util.logging.Level")$SEVERE)
 } 
 

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -29,43 +29,36 @@
       }
 
       # Determine classpath for netCDF-Java based on R option, environment variable, or fallback
-      cp_opt <- getOption("loadeR.netcdf_java_classpath", "")
-      cp_env <- Sys.getenv("LOADER_NETCDF_JAVA_CLASSPATH", "")
+      cp_opt <- getOption("loadeR.java_classpath", "")
+      cp_env <- Sys.getenv("LOADER_JAVA_CLASSPATH", "")
        
       cp_msg <- NULL
       cp_entries <- character()
-
-      # If both R option and environment variable are set, R option takes precedence
-      if (cp_opt != "" && cp_env != "" && cp_opt != cp_env) {
-            # Check if the user has enabled strict mode: if TRUE, stop on conflicting classpath values; if FALSE (default), just warn
-            if (getOption("loadeR.netcdf_java_classpath_strict", FALSE)) {
-                  stop("Conflicting netCDF-Java classpath: both R option and environment variable are set")
-            } else {
-                  warning("Conflicting netCDF-Java classpath: both R option and environment variable are set. Using R option value.")
-            }
-      }
+ 
       if (cp_opt != "") {
             # Use the classpath specified in the R option
-            cp_msg <- "R option loadeR.netcdf_java_classpath" 
-            cp_entries <- strsplit(cp_opt, .Platform$path.sep, fixed = TRUE)[[1]]
-      } else if (cp_env != "") {
+            cp_msg <- "R option loadeR.java_classpath" 
+            cp_entries <- c(cp_entries, strsplit(cp_opt, .Platform$path.sep, fixed = TRUE)[[1]])
+      } 
+      if (cp_env != "") {
             # Use the classpath specified in the environment variable
-            cp_msg <- "env LOADER_NETCDF_JAVA_CLASSPATH" 
-            cp_entries <- strsplit(cp_env, .Platform$path.sep, fixed = TRUE)[[1]]
-      } else {
-            # Use java package directory as fallback
-            cp_msg <- "bundled java package directory"
-            # Include all jar files in the java package directory 
-            java_path <- system.file("java", package = pkgname) 
-            jar_files <- list.files(java_path, pattern = "\\.jar$", full.names = TRUE)
-            # Include all directories in the java package directory 
-            all_entries <- list.files(java_path, full.names = TRUE)
-            dir_entries <- all_entries[file.info(all_entries)$isdir]
-            # Include the java package directory itself 
-            cp_entries <- c(java_path, jar_files, dir_entries)
-      }
+            cp_msg <- if (is.null(cp_msg)) "env LOADER_JAVA_CLASSPATH" else paste(cp_msg, "+ env LOADER_JAVA_CLASSPATH")
+            cp_entries <- c(cp_entries, strsplit(cp_env, .Platform$path.sep, fixed = TRUE)[[1]])
+      } 
+      # Use java package directory as fallback
+      cp_msg <- if (is.null(cp_msg)) "bundled java package directory" else paste(cp_msg, "+ bundled java package directory")
+      # Include all jar files in the java package directory 
+      java_path <- system.file("java", package = pkgname) 
+      jar_files <- list.files(java_path, pattern = "\\.jar$", full.names = TRUE)
+      # Include all zip files in the java package directory 
+      zip_files <- list.files(java_path, pattern = "\\.zip$", full.names = TRUE)
+      # Include all directories in the java package directory 
+      all_entries <- list.files(java_path, full.names = TRUE)
+      dir_entries <- all_entries[file.info(all_entries)$isdir]
+      cp_entries <- c(cp_entries, java_path, jar_files, zip_files, dir_entries)
+
       # Clean empty or whitespace entries
-      cp_entries <- unique(trimws(cp_entries))
+      cp_entries <- trimws(cp_entries)
       cp_entries <- cp_entries[cp_entries != ""]
 
       # Expand entries
@@ -82,5 +75,5 @@
             warning("JVM is already initialized; the netCDF-Java classpath was added at runtime (consider restarting R to apply it from startup).")
       }
       # Save classpath info for display when attaching the package
-      options(loadeR.netcdf_java_classpath_msg = cp_msg, loadeR.netcdf_java_classpath_entries = cp_entries)
+      options(loadeR.java_classpath_msg = cp_msg, loadeR.java_classpath_entries = cp_entries)
 }

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -28,12 +28,62 @@
             warning("JVM is already initialized; java.parameters could not be set.")
       }
 
-      # Get the correct path to the 'java' directory inside the package
-      java_path <- system.file("java", package = pkgname)
+      # Determine classpath for netCDF-Java based on R option, environment variable, or fallback
+      cp_opt <- getOption("loadeR.netcdf_java_classpath", "")
+      cp_env <- Sys.getenv("LOADER_NETCDF_JAVA_CLASSPATH", "")
+      cp_source <- NULL # Selected classpath source (cp_opt, cp_env, or fallback)
+      cp_msg <- NULL # Message of selected classpath source (for display when attaching the package)
+      cp_entries <- character()
 
-      # Get path to all JAR files in the 'java' directory 
-      jar_files <- list.files(java_path, pattern = "\\.jar$", full.names = TRUE)
+      # If both R option and environment variable are set, R option takes precedence
+      if (cp_opt != "" && cp_env != "" && cp_opt != cp_env) {
+            # Check if the user has enabled strict mode: if TRUE, stop on conflicting classpath values; if FALSE (default), just warn
+            if (getOption("loadeR.java.strict_classpath", FALSE)) {
+                  stop("Conflicting netCDF-Java classpath: both R option and environment variable are set")
+            } else {
+                  warning("Conflicting netCDF-Java classpath: both R option and environment variable are set. Using R option value.")
+            }
+      }
+      if (cp_opt != "") {
+            # Use the classpath specified in the R option
+            cp_msg <- "R option loadeR.netcdf_java_classpath"
+            cp_source <- cp_opt
+            cp_entries <- strsplit(cp_opt, .Platform$path.sep, fixed = TRUE)[[1]]
+      } else if (cp_env != "") {
+            # Use the classpath specified in the environment variable
+            cp_msg <- "env LOADER_NETCDF_JAVA_CLASSPATH"
+            cp_source <- cp_env
+            cp_entries <- strsplit(cp_env, .Platform$path.sep, fixed = TRUE)[[1]]
+      } else {
+            # Use bundled JARs and directories under inst/java as fallback
+            cp_msg <- "bundled inst/java/*"
+            java_path <- system.file("java", package = pkgname)
+            cp_source <- file.path(java_path, "*")
+            # Include all JAR files in inst/java
+            jar_files <- list.files(java_path, pattern = "\\.jar$", full.names = TRUE)
+            # Include all directories in inst/java
+            all_entries <- list.files(java_path, full.names = TRUE)
+            dir_entries <- all_entries[file.info(all_entries)$isdir]
+            # Include inst/java itself 
+            cp_entries <- c(java_path, jar_files, dir_entries)
+      }
+      # Clean empty or whitespace entries
+      cp_entries <- unique(trimws(cp_entries))
+      cp_entries <- cp_entries[cp_entries != ""]
 
-      # Force JVM initialization with JAR classpath if not already done 
-      if (!rJava::.jniInitialized) rJava::.jinit(classpath = jar_files)
+      # Expand entries
+      expanded_entries <- unique(unlist(lapply(path.expand(cp_entries), Sys.glob)))
+
+      # Initialize the JVM with the determined classpath if not already running
+      if (!rJava::.jniInitialized) {
+            rJava::.jinit(classpath = expanded_entries)
+      } else {
+            # If JVM is already running, add classpath entries 
+            for (cp in expanded_entries) {
+                  rJava::.jaddClassPath(cp)
+            }
+            warning("JVM is already initialized; the netCDF-Java classpath was added at runtime (consider restarting R to apply it from startup).")
+      }
+      # Save classpath info for display when attaching the package
+      options(loadeR.netcdf_java_classpath_msg = cp_msg, loadeR.netcdf_java_classpath_source = cp_source)
 }

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -47,15 +47,14 @@
       } 
       # Use java package directory as fallback
       cp_msg <- if (is.null(cp_msg)) "bundled java package directory" else paste(cp_msg, "+ bundled java package directory")
-      # Include all jar files in the java package directory 
+      # Include jar/zip files and first-level subdirectories from java package directory
       java_path <- system.file("java", package = pkgname) 
-      jar_files <- list.files(java_path, pattern = "\\.jar$", full.names = TRUE)
-      # Include all zip files in the java package directory 
-      zip_files <- list.files(java_path, pattern = "\\.zip$", full.names = TRUE)
-      # Include all directories in the java package directory 
-      all_entries <- list.files(java_path, full.names = TRUE)
-      dir_entries <- all_entries[file.info(all_entries)$isdir]
-      cp_entries <- c(cp_entries, java_path, jar_files, zip_files, dir_entries)
+      java_entries <- c(
+            list.files(java_path, pattern = "\\.(jar|zip)$", full.names = TRUE), 
+            setdiff(list.dirs(java_path, recursive = FALSE, full.names = TRUE), java_path)
+      )
+      java_entries <- sort(java_entries, decreasing = FALSE)
+      cp_entries <- c(cp_entries, java_path, java_entries)
 
       # Clean empty or whitespace entries
       cp_entries <- trimws(cp_entries)

--- a/R/onLoad.R
+++ b/R/onLoad.R
@@ -31,14 +31,14 @@
       # Determine classpath for netCDF-Java based on R option, environment variable, or fallback
       cp_opt <- getOption("loadeR.netcdf_java_classpath", "")
       cp_env <- Sys.getenv("LOADER_NETCDF_JAVA_CLASSPATH", "")
-      cp_source <- NULL # Selected classpath source (cp_opt, cp_env, or fallback)
-      cp_msg <- NULL # Message of selected classpath source (for display when attaching the package)
+       
+      cp_msg <- NULL
       cp_entries <- character()
 
       # If both R option and environment variable are set, R option takes precedence
       if (cp_opt != "" && cp_env != "" && cp_opt != cp_env) {
             # Check if the user has enabled strict mode: if TRUE, stop on conflicting classpath values; if FALSE (default), just warn
-            if (getOption("loadeR.java.strict_classpath", FALSE)) {
+            if (getOption("loadeR.netcdf_java_classpath_strict", FALSE)) {
                   stop("Conflicting netCDF-Java classpath: both R option and environment variable are set")
             } else {
                   warning("Conflicting netCDF-Java classpath: both R option and environment variable are set. Using R option value.")
@@ -46,25 +46,22 @@
       }
       if (cp_opt != "") {
             # Use the classpath specified in the R option
-            cp_msg <- "R option loadeR.netcdf_java_classpath"
-            cp_source <- cp_opt
+            cp_msg <- "R option loadeR.netcdf_java_classpath" 
             cp_entries <- strsplit(cp_opt, .Platform$path.sep, fixed = TRUE)[[1]]
       } else if (cp_env != "") {
             # Use the classpath specified in the environment variable
-            cp_msg <- "env LOADER_NETCDF_JAVA_CLASSPATH"
-            cp_source <- cp_env
+            cp_msg <- "env LOADER_NETCDF_JAVA_CLASSPATH" 
             cp_entries <- strsplit(cp_env, .Platform$path.sep, fixed = TRUE)[[1]]
       } else {
-            # Use bundled JARs and directories under inst/java as fallback
-            cp_msg <- "bundled inst/java/*"
-            java_path <- system.file("java", package = pkgname)
-            cp_source <- file.path(java_path, "*")
-            # Include all JAR files in inst/java
+            # Use java package directory as fallback
+            cp_msg <- "bundled java package directory"
+            # Include all jar files in the java package directory 
+            java_path <- system.file("java", package = pkgname) 
             jar_files <- list.files(java_path, pattern = "\\.jar$", full.names = TRUE)
-            # Include all directories in inst/java
+            # Include all directories in the java package directory 
             all_entries <- list.files(java_path, full.names = TRUE)
             dir_entries <- all_entries[file.info(all_entries)$isdir]
-            # Include inst/java itself 
+            # Include the java package directory itself 
             cp_entries <- c(java_path, jar_files, dir_entries)
       }
       # Clean empty or whitespace entries
@@ -72,18 +69,18 @@
       cp_entries <- cp_entries[cp_entries != ""]
 
       # Expand entries
-      expanded_entries <- unique(unlist(lapply(path.expand(cp_entries), Sys.glob)))
+      cp_entries <- unique(unlist(lapply(path.expand(cp_entries), Sys.glob)))
 
       # Initialize the JVM with the determined classpath if not already running
       if (!rJava::.jniInitialized) {
-            rJava::.jinit(classpath = expanded_entries)
+            rJava::.jinit(classpath = cp_entries)
       } else {
             # If JVM is already running, add classpath entries 
-            for (cp in expanded_entries) {
+            for (cp in cp_entries) {
                   rJava::.jaddClassPath(cp)
             }
             warning("JVM is already initialized; the netCDF-Java classpath was added at runtime (consider restarting R to apply it from startup).")
       }
       # Save classpath info for display when attaching the package
-      options(loadeR.netcdf_java_classpath_msg = cp_msg, loadeR.netcdf_java_classpath_source = cp_source)
+      options(loadeR.netcdf_java_classpath_msg = cp_msg, loadeR.netcdf_java_classpath_entries = cp_entries)
 }

--- a/README.md
+++ b/README.md
@@ -11,36 +11,24 @@ options(java.parameters = "-Xmx4g") # Set maximum heap space to 4 GB
 library(loadeR.java)
 ```
 
-### Configuring the netCDF-Java Classpath
+### Configuring netCDF-Java classpath
 
-By default, **loadeR.java** will use the bundled JARs found in the java package directory.  
-Advanced users can override this behavior to point to their own `netCDF-Java` setup (e.g., for development or production deployments).
+By default, **loadeR.java** will use `netCDF-Java` JARs found in the java package directory. Users can point to their own `netCDF-Java` classpath, using a [netCDF-Java library](https://downloads.unidata.ucar.edu/netcdf-java/) installation.
 
-Classpath precedence:
+**loadeR.java** provides options for defining the `netCDF-Java` classpath, which are considered in the following order of precedence:
 1. R option: `loadeR.java_classpath`
 2. Environment variable: `LOADER_JAVA_CLASSPATH`
 3. Bundled fallback: java package directory
 
-Each method accepts one or more classpath entries, separated by the platform path separator (`:` on Linux/macOS, `;` on Windows). Wildcards (`*`) are supported.
+Each method accepts one or more classpath entries, separated by the platform path separator (`:` on Linux/macOS, `;` on Windows). Wildcards (`*`) are supported. In the case of using `*`, the order of precedence within the same option follows lexicographic order (ascending).
 
-#### Example: Production (single JAR)
+#### Example: R option
 ```r
 options(loadeR.java_classpath = "/opt/netcdf-java/netcdfAll-5.9.0.jar")
 library(loadeR.java)
 ```
-
-#### Example: Development (directories + jars)
-```r
-options(loadeR.java_classpath = paste(
-  "~/dev/netcdf-java/cdm/build/classes/java/main",
-  "~/dev/netcdf-java/cdm/build/resources/main",
-  "~/dev/netcdf-java/grib/build/classes/java/main",
-  "~/dev/netcdf-java/grib/build/resources/main",
-  sep = .Platform$path.sep
-))
-library(loadeR.java)
-```
-#### Example: Environment variable (persistent, default)
+ 
+#### Example: Environment variable 
 ```bash
 # Linux/macOS
 export LOADER_JAVA_CLASSPATH="/opt/netcdf-java/lib/*"
@@ -51,14 +39,14 @@ $env:LOADER_JAVA_CLASSPATH = "C:\netcdf-java\lib\*"
 R -NoSave -e "library(loadeR.java)"
 ```
 
-#### Bundled fallback (no config)
-* Drop any required jars and directory into the java package directory.
+#### Bundled fallback 
+* Drop any required JARs into the java package directory.
 
-### NetCDF-Java Version Detection (MANIFEST.MF)
+### Configuring netCDF-Java version
 
 On startup, **loadeR.java** tries to detect the `netCDF-Java` version from the JAR’s `MANIFEST.MF` file.  
 
-If you are using development directories or classpaths without a MANIFEST, the version cannot be detected automatically. You can manually set the NetCDF Java Library version using an R option before loading the package:
+If no `MANIFEST.MF` is found, the version cannot be detected automatically. You can manually set the `netCDF-Java` library version using an R option before loading the package:
 
 ```r
 options(loadeR.java_forced_version = "5.9.0")

--- a/README.md
+++ b/README.md
@@ -17,21 +17,21 @@ By default, **loadeR.java** will use the bundled JARs found in the java package 
 Advanced users can override this behavior to point to their own `netCDF-Java` setup (e.g., for development or production deployments).
 
 Classpath precedence:
-1. R option: `loadeR.netcdf_java_classpath`
-2. Environment variable: `LOADER_NETCDF_JAVA_CLASSPATH`
+1. R option: `loadeR.java_classpath`
+2. Environment variable: `LOADER_JAVA_CLASSPATH`
 3. Bundled fallback: java package directory
 
 Each method accepts one or more classpath entries, separated by the platform path separator (`:` on Linux/macOS, `;` on Windows). Wildcards (`*`) are supported.
 
 #### Example: Production (single JAR)
 ```r
-options(loadeR.netcdf_java_classpath = "/opt/netcdf-java/netcdfAll-5.9.0.jar")
+options(loadeR.java_classpath = "/opt/netcdf-java/netcdfAll-5.9.0.jar")
 library(loadeR.java)
 ```
 
 #### Example: Development (directories + jars)
 ```r
-options(loadeR.netcdf_java_classpath = paste(
+options(loadeR.java_classpath = paste(
   "~/dev/netcdf-java/cdm/build/classes/java/main",
   "~/dev/netcdf-java/cdm/build/resources/main",
   "~/dev/netcdf-java/grib/build/classes/java/main",
@@ -43,11 +43,11 @@ library(loadeR.java)
 #### Example: Environment variable (persistent, default)
 ```bash
 # Linux/macOS
-export LOADER_NETCDF_JAVA_CLASSPATH="/opt/netcdf-java/lib/*"
+export LOADER_JAVA_CLASSPATH="/opt/netcdf-java/lib/*"
 R -q -e "library(loadeR.java)"
 
 # Windows PowerShell
-$env:LOADER_NETCDF_JAVA_CLASSPATH = "C:\netcdf-java\lib\*"
+$env:LOADER_JAVA_CLASSPATH = "C:\netcdf-java\lib\*"
 R -NoSave -e "library(loadeR.java)"
 ```
 
@@ -58,10 +58,9 @@ R -NoSave -e "library(loadeR.java)"
 
 On startup, **loadeR.java** tries to detect the `netCDF-Java` version from the JAR’s `MANIFEST.MF` file.  
 
-If you are using development directories or classpaths without a MANIFEST, the version cannot be detected automatically.  
-In that case, you can set it manually before loading the package:
+If you are using development directories or classpaths without a MANIFEST, the version cannot be detected automatically. You can manually set the NetCDF Java Library version using an R option before loading the package:
 
 ```r
-options(loadeR.java.forced_version = "5.9.0")
+options(loadeR.java_forced_version = "5.9.0")
 library(loadeR.java)
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ options(loadeR.netcdf_java_classpath = paste(
 library(loadeR.java)
 ```
 #### Example: Environment variable (persistent, default)
-```r
+```bash
 # Linux/macOS
 export LOADER_NETCDF_JAVA_CLASSPATH="/opt/netcdf-java/lib/*"
 R -q -e "library(loadeR.java)"
@@ -53,3 +53,15 @@ R -NoSave -e "library(loadeR.java)"
 
 #### Bundled fallback (no config)
 * Drop any required jars and directory into the java package directory.
+
+### NetCDF-Java Version Detection (MANIFEST.MF)
+
+On startup, **loadeR.java** tries to detect the `netCDF-Java` version from the JAR’s `MANIFEST.MF` file.  
+
+If you are using development directories or classpaths without a MANIFEST, the version cannot be detected automatically.  
+In that case, you can set it manually before loading the package:
+
+```r
+options(loadeR.java.forced_version = "5.9.0")
+library(loadeR.java)
+```

--- a/README.md
+++ b/README.md
@@ -8,4 +8,48 @@ If the Java Virtual Machine (JVM) is already initialized (e.g., by another packa
 
 ```r
 options(java.parameters = "-Xmx4g") # Set maximum heap space to 4 GB
-library(loadeR.java) 
+library(loadeR.java)
+```
+
+### Configuring the netCDF-Java Classpath
+
+By default, **loadeR.java** will use the bundled JARs found in the java package directory.  
+Advanced users can override this behavior to point to their own `netCDF-Java` setup (e.g., for development or production deployments).
+
+Classpath precedence:
+1. R option: `loadeR.netcdf_java_classpath`
+2. Environment variable: `LOADER_NETCDF_JAVA_CLASSPATH`
+3. Bundled fallback: java package directory
+
+Each method accepts one or more classpath entries, separated by the platform path separator (`:` on Linux/macOS, `;` on Windows). Wildcards (`*`) are supported.
+
+#### Example: Production (single JAR)
+```r
+options(loadeR.netcdf_java_classpath = "/opt/netcdf-java/netcdfAll-5.9.0.jar")
+library(loadeR.java)
+```
+
+#### Example: Development (directories + jars)
+```r
+options(loadeR.netcdf_java_classpath = paste(
+  "~/dev/netcdf-java/cdm/build/classes/java/main",
+  "~/dev/netcdf-java/cdm/build/resources/main",
+  "~/dev/netcdf-java/grib/build/classes/java/main",
+  "~/dev/netcdf-java/grib/build/resources/main",
+  sep = .Platform$path.sep
+))
+library(loadeR.java)
+```
+#### Example: Environment variable (persistent, default)
+```r
+# Linux/macOS
+export LOADER_NETCDF_JAVA_CLASSPATH="/opt/netcdf-java/lib/*"
+R -q -e "library(loadeR.java)"
+
+# Windows PowerShell
+$env:LOADER_NETCDF_JAVA_CLASSPATH = "C:\netcdf-java\lib\*"
+R -NoSave -e "library(loadeR.java)"
+```
+
+#### Bundled fallback (no config)
+* Drop any required jars and directory into the java package directory.

--- a/tests/testthat/test-loadeRjava.R
+++ b/tests/testthat/test-loadeRjava.R
@@ -25,3 +25,39 @@ test_that("javaString2rChar", {
   expect_equal(rstr, "Word")
   expect_type(rstr, "character")
 })
+ 
+# ============================
+# Test: Classpath precedence
+# ============================
+
+test_that("user-defined classpath precedes system CLASSPATH", {
+  res <- callr::r(function() {
+    # Temporary directories for system CLASSPATH and user-defined classpath
+    sys_cp <- tempfile("syscp_"); dir.create(sys_cp)
+    usr_cp <- tempfile("usrcp_"); dir.create(usr_cp)
+
+    # Set system CLASSPATH before starting the JVM
+    Sys.setenv(CLASSPATH = sys_cp)
+
+    # Start the JVM with an explicit user-defined classpath
+    rJava::.jinit(classpath = usr_cp)
+
+    # Normalized paths for system CLASSPATH and user-defined classpath
+    paths <- normalizePath(rJava::.jclassPath(), winslash = "/", mustWork = FALSE)
+    sys_cp <- normalizePath(sys_cp, winslash = "/", mustWork = FALSE)
+    usr_cp <- normalizePath(usr_cp, winslash = "/", mustWork = FALSE)
+
+    # Return 
+    list(paths = paths, sys_cp = sys_cp, usr_cp = usr_cp)
+  })
+
+  # Results
+  paths <- res$paths
+  sys_cp <- res$sys_cp
+  usr_cp <- res$usr_cp
+
+  # Assertions
+  expect_true(any(paths == usr_cp)) # User-defined classpath is present
+  expect_true(any(paths == sys_cp)) # System CLASSPATH is present
+  expect_lt(which(paths == usr_cp), which(paths == sys_cp)) # User comes before system
+})


### PR DESCRIPTION
# Add configurable classpath support for netCDF-Java

### Summary
This PR implements a configurable mechanism for defining the Java classpath used by **loadeR.java**, enabling developers and users to flexibly switch between different `netCDF-Java` setups without modifying the package code.

### Key Features
- **Classpath precedence**:
  1. R option: `loadeR.netcdf_java_classpath`
  2. Environment variable: `LOADER_NETCDF_JAVA_CLASSPATH`
  3. Bundled fallback: JARs and directories in the java package directory

- **Conflict handling**:  
  - If both R option and env var are set, the R option takes precedence.  
  - Strict mode can be enabled with `options(loadeR.netcdf_java_classpath_strict = TRUE)` to throw an error instead of a warning.

- **Runtime behavior**:  
  - If the JVM is already initialized, new classpath entries are added dynamically.  
  - Expanded entries (support for `~`, wildcards via `Sys.glob`).

- **Startup messages**:  
  - Reports which source provided the netCDF-Java classpath.  
  - Displays the detected (or forced) NetCDF-Java version.

- **Optional manual version**:  
  - If the MANIFEST cannot be found, users can provide `options(loadeR.java.forced_version = "x.y.z")`.

### Tests
- Added **test-loadeRjava.R** to verify that:
  - User-defined classpath is present.
  - System `CLASSPATH` is preserved.
  - User-defined classpath precedes system classpath (`.jclassPath()` order).